### PR TITLE
Map overlay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 
 script:
   - cd backend
+  - npm install
   - node server.js &
   - cd ../frontend
   - npm run test -- --watch=false --no-progress --browsers=ChromeHeadlessNoSandbox

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -222,7 +222,7 @@
         "convert-source-map": "^1.5.1",
         "dependency-graph": "^0.7.2",
         "magic-string": "^0.25.0",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.2",
         "reflect-metadata": "^0.1.2",
         "source-map": "^0.6.1",
         "tslib": "^1.9.0",

--- a/frontend/src/app/apple.service.ts
+++ b/frontend/src/app/apple.service.ts
@@ -20,7 +20,7 @@ export class AppleService {
   getApples(): Observable<any> {
 
     // return this.http.get(this.baseurl + '/apples/', {headers: this.httpHeaders});
-    return this.http.get('http://127.0.01:3000/beta/query1');
+    return this.http.get('http://127.0.0.1:3000/beta/query1');
    
   }
  

--- a/frontend/src/app/map/map.component.ts
+++ b/frontend/src/app/map/map.component.ts
@@ -43,6 +43,7 @@ export class MapComponent implements OnInit {
   private map: L.map;
   apples: Apple[] = [];
   markers: L.marker[];
+  clusters: L.markercluster;
 
   constructor(public infoPanelService: InfoPanelService, public appleService: AppleService) { 
   }
@@ -65,32 +66,14 @@ export class MapComponent implements OnInit {
           console.log(error);
         });
   }
-  
-  private initMap(): void {
-    // Setting location to Boulder
-    this.markers = [];
-    var p1 = L.latLng(40.149152, -105.378020),
-    p2 = L.latLng(39.957245, -105.170137),
-    bounds = L.latLngBounds(p1, p2);
-    this.map = L.map('map', {
-      // maxBounds: bounds
-    }).setView([40.0150, -105.2705], 12.5);
 
-    // World Tile Layer
-    // L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    //     attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    // }).addTo(map);
-    var Esri_WorldTopoMap = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}', {
-      attribution: 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community'
-    }).addTo(this.map)
-
-    // Apple Markers
-
+  createAppleMarkers(this): L.markerClusterGroup {
     var treeIcon = L.icon({
       iconUrl: '../assets/icons8-color-48.png',
 
       iconSize: [40,40]
     });
+
     L.DomUtil.TRANSITION = true;
     var clusterMarkers = L.markerClusterGroup({
       maxClusterRadius: 20,
@@ -134,12 +117,43 @@ export class MapComponent implements OnInit {
       // console.log(this.markers);
       // L.featureGroup(this.markers)
         // .addTo(this.map);
-      this.map.addLayer(clusterMarkers);
-      });
+    });
+
+    return clusterMarkers;
+  }
+  
+  private initMap(): void {
+    // Setting location to Boulder
+    this.markers = [];
+    var p1 = L.latLng(40.149152, -105.378020),
+    p2 = L.latLng(39.957245, -105.170137),
+    bounds = L.latLngBounds(p1, p2);
+    this.map = L.map('map', {
+      // maxBounds: bounds
+    }).setView([40.0150, -105.2705], 12.5);
+
+    // Historic map layer
+    var mapurl = '../assets/Copy of 1937 Aerial Photo_Earth Sciences.png',
+        imageBounds = [[40.052809, -105.308255], [39.973041, -105.245940]];
+
+    L.imageOverlay(mapurl, imageBounds, { opacity: 0.6 }).addTo(this.map);
+
+    // World Tile Layer
+    // L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    //     attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    // }).addTo(map);
+    var Esri_WorldTopoMap = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}', {
+      attribution: 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community'
+    }).addTo(this.map)
+
+    // Apple Markers
+    this.clusters = this.createAppleMarkers();
+    this.map.addLayer(this.clusters);
   }
 
   ngOnInit() {
     this.initMap();
   }
+
 
 }

--- a/frontend/src/app/map/map.component.ts
+++ b/frontend/src/app/map/map.component.ts
@@ -128,27 +128,48 @@ export class MapComponent implements OnInit {
     var p1 = L.latLng(40.149152, -105.378020),
     p2 = L.latLng(39.957245, -105.170137),
     bounds = L.latLngBounds(p1, p2);
-    this.map = L.map('map', {
-      // maxBounds: bounds
-    }).setView([40.0150, -105.2705], 12.5);
 
     // Historic map layer
     var mapurl = '../assets/Copy of 1937 Aerial Photo_Earth Sciences.png',
-        imageBounds = [[40.052809, -105.308255], [39.973041, -105.245940]];
+        imageBounds = [[40.052709, -105.309205], [39.973121, -105.245030]];
 
-    L.imageOverlay(mapurl, imageBounds, { opacity: 0.6 }).addTo(this.map);
+    var historic_map = L.imageOverlay(mapurl, imageBounds, { opacity: 0.7 });
 
-    // World Tile Layer
-    // L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    //     attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    // }).addTo(map);
+    // Different world tile layers
     var Esri_WorldTopoMap = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}', {
       attribution: 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community'
-    }).addTo(this.map)
+    });
+
+    var Esri_WorldImagery = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+      attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
+    });
+
+    var Stadia_AlidadeSmoothDark = L.tileLayer('https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png', {
+      maxZoom: 20,
+      attribution: '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+    });
+
+    this.map = L.map('map', {
+      // maxBounds: bounds
+      layers: [Esri_WorldTopoMap]
+    }).setView([40.0150, -105.2705], 12.5);
 
     // Apple Markers
     this.clusters = this.createAppleMarkers();
     this.map.addLayer(this.clusters);
+
+    var baseLayers = {
+      "Topological": Esri_WorldTopoMap,
+      "Greyscale": Stadia_AlidadeSmoothDark,
+      "Terrain": Esri_WorldImagery
+    }
+
+    var overlayMaps = {
+      "1920s Historic Map of Boulder": historic_map 
+    };
+
+    L.control.layers(baseLayers, overlayMaps).addTo(this.map);
+
   }
 
   ngOnInit() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Add a layer control button (top right) which allows user to switch between three different type of world maps (terrain, grayscale, and satellite). Also added an overlay for the 1920s historic map to a close enough location - not perfect since I think the aerial might be a little slanted but it works well. Also fixed a security vulnerability alert I was getting in GitHub and fixed travis to update backend node modules. 